### PR TITLE
Add OnBeforeWrite wiki

### DIFF
--- a/Configure-tusdotnet.md
+++ b/Configure-tusdotnet.md
@@ -106,6 +106,7 @@ Once the file is completely uploaded the `OnFileComplete` event will fire.
 
 Each event is described below:
 * [OnAuthorize](OnAuthorizeAsync-event)
+* [OnBeforeWrite](OnBeforeWrite-event)
 * [OnFileComplete](Processing-a-file-once-the-file-upload-is-complete)
 * [OnBeforeCreate](OnBeforeCreate-event)
 * [OnCreateComplete](OnCreateComplete-event)

--- a/OnBeforeCreate-event.md
+++ b/OnBeforeCreate-event.md
@@ -25,5 +25,6 @@ app.UseTus(context => new DefaultTusConfiguration
 
 			return Task.CompletedTask;
 		}
+	}
 });
 ```

--- a/OnBeforeWrite-event.md
+++ b/OnBeforeWrite-event.md
@@ -1,11 +1,12 @@
 The OnBeforeWrite event is fired just before handling each file data upload request (i.e., each HTTP PATCH request containing a chunk of file data). It allows inspecting the upload and optionally rejecting the request before any data is written to storage.
 
-If reading or inspecting the upload content (the HTTP request body) is needed, please keep in mind these points:
+If you need to read or inspect the uploaded content (the HTTP request body), it is *highly* recommended to use pipelines, if available and supported by the `ITusStore` in use. The PipeReader implementation (`HttpContext.Request.BodyReader`) includes built-in buffering, whereas the Stream implementation (`HttpContext.Request.Body`) does not.
 
-- Using `HttpRequest.EnableBuffering()` to rewind the body stream is not suggested. This causes the content to be written to disk twice (once by the buffering mechanism and again by tusdotnet configured store) and creates unnecessary disk I/O and performance issues.
-- Recommended way is to read the request body with some `PipeReader` and buffering only what is needed. Ideal steps for this:
-    - Wrap the original stream in a rewindable wrapper (like a `MemoryStream`) before handing it back to the tusdotnet pipeline
-    - Ensure your replacement stream is compatible with `TusDiskStore` or your custom `ITusStore` implementation
+If you must use the Stream implementation, please consider the following points:
+
+- The Stream can only be read once because it is not seekable. Buffering must be enabled for it to function correctly.
+
+- Using `HttpRequest.EnableBuffering()` to rewind the body stream is a quick solution, but it has downsides when using `TusDiskStore`. It causes the content to be written to disk twice — first by the buffering mechanism and again by the tusdotnet configured store, resulting in unnecessary disk I/O and performance issues.
 
 Calling `FailRequest` on the `BeforeWriteContext` passed to the callback will reject the request with a 400 Bad Request status code. Calling `FailRequest` multiple times will concatenate the error messages.
 
@@ -20,10 +21,6 @@ app.UseTus(context => new DefaultTusConfiguration
 	{
 		OnBeforeWriteAsync = ctx =>
 		{
-			if (ctx.Store.GetUploadOffsetAsync(ctx.FileId, CancellationToken.None).Result != ctx.UploadOffset)
-			{
-				ctx.FailRequest(HttpStatusCode.BadRequest);
-			}
 			if (!SomeBusinessLogic())
 			{
 				ctx.FailRequest("Failing request due to some business logic")
@@ -34,3 +31,39 @@ app.UseTus(context => new DefaultTusConfiguration
     }
 });
 ```
+
+```csharp
+app.UseTus(context => new DefaultTusConfiguration
+{
+	UrlPath = "/files",
+	Store = new TusDiskStore(@"C:\tusfiles\"),
+	Events = new Events
+	{
+		OnBeforeWriteAsync = ctx =>
+		{
+			if (ctx.UploadOffset is not 0)
+				return;
+
+			var read = await ctx.HttpContext.Request.BodyReader.ReadAtLeastAsync(
+				10,
+				ctx.CancellationToken
+			);
+
+			var isValid = IsValidFileSignature(read.Buffer);
+
+			if (isValid)
+			{
+				logger.LogInformation("File contains the data needed");
+			}
+			else
+			{
+				ctx.FailRequest("File is invalid");
+			}
+
+			ctx.HttpContext.Request.BodyReader.AdvanceTo(read.Buffer.Start, read.Buffer.Start);
+		},
+    }
+});
+```
+
+> :information_source: Note that the content may not be complete in the request as the client could be sending 1 byte or 10 GB of data.

--- a/OnBeforeWrite-event.md
+++ b/OnBeforeWrite-event.md
@@ -1,4 +1,11 @@
-The OnBeforeWrite event is fired just before each file data upload request (PATCH).
+The OnBeforeWrite event is fired just before handling each file data upload request (i.e., each HTTP PATCH request containing a chunk of file data). It allows inspecting the upload and optionally rejecting the request before any data is written to storage.
+
+If reading or inspecting the upload content (the HTTP request body) is needed, please keep in mind these points:
+
+- Using `HttpRequest.EnableBuffering()` to rewind the body stream is not suggested. This causes the content to be written to disk twice (once by the buffering mechanism and again by tusdotnet configured store) and creates unnecessary disk I/O and performance issues.
+- Recommended way is to read the request body with some `PipeReader` and buffering only what is needed. Ideal steps for this:
+    - Wrap the original stream in a rewindable wrapper (like a `MemoryStream`) before handing it back to the tusdotnet pipeline
+    - Ensure your replacement stream is compatible with `TusDiskStore` or your custom `ITusStore` implementation
 
 Calling `FailRequest` on the `BeforeWriteContext` passed to the callback will reject the request with a 400 Bad Request status code. Calling `FailRequest` multiple times will concatenate the error messages.
 
@@ -13,7 +20,7 @@ app.UseTus(context => new DefaultTusConfiguration
 	{
 		OnBeforeWriteAsync = ctx =>
 		{
-			if (ctx.UploadLength == 0)
+            if (ctx.Store.GetUploadOffsetAsync(ctx.FileId, CancellationToken.None).Result != ctx.UploadOffset)
             {
                 ctx.FailRequest(HttpStatusCode.BadRequest);
             }

--- a/OnBeforeWrite-event.md
+++ b/OnBeforeWrite-event.md
@@ -20,14 +20,14 @@ app.UseTus(context => new DefaultTusConfiguration
 	{
 		OnBeforeWriteAsync = ctx =>
 		{
-            if (ctx.Store.GetUploadOffsetAsync(ctx.FileId, CancellationToken.None).Result != ctx.UploadOffset)
-            {
-                ctx.FailRequest(HttpStatusCode.BadRequest);
-            }
-            if (!SomeBusinessLogic())
-            {
-                ctx.FailRequest("Failing request due to some business logic")
-            }
+			if (ctx.Store.GetUploadOffsetAsync(ctx.FileId, CancellationToken.None).Result != ctx.UploadOffset)
+			{
+				ctx.FailRequest(HttpStatusCode.BadRequest);
+			}
+			if (!SomeBusinessLogic())
+			{
+				ctx.FailRequest("Failing request due to some business logic")
+			}
 
 			return Task.CompletedTask;
 		}

--- a/OnBeforeWrite-event.md
+++ b/OnBeforeWrite-event.md
@@ -1,0 +1,29 @@
+The OnBeforeWrite event is fired just before each file data upload request (PATCH).
+
+Calling `FailRequest` on the `BeforeWriteContext` passed to the callback will reject the request with a 400 Bad Request status code. Calling `FailRequest` multiple times will concatenate the error messages.
+
+> :information_source: Note that this event only fires for client requests and not when manually calling the store's methods.
+
+```csharp
+app.UseTus(context => new DefaultTusConfiguration
+{
+	UrlPath = "/files",
+	Store = new TusDiskStore(@"C:\tusfiles\"),
+	Events = new Events
+	{
+		OnBeforeWriteAsync = ctx =>
+		{
+			if (ctx.UploadLength == 0)
+            {
+                ctx.FailRequest(HttpStatusCode.BadRequest);
+            }
+            if (!SomeBusinessLogic())
+            {
+                ctx.FailRequest("Failing request due to some business logic")
+            }
+
+			return Task.CompletedTask;
+		}
+    }
+});
+```


### PR DESCRIPTION
- Added `OnBeforeWrite` event wiki and detailed some information about reading the request body.
- Fixed a wiki file that was missing one `}`.

As a side note, would it be possible to release this event as a minor patch? It is needed by my project.